### PR TITLE
url for colab is missing /noteboooks/ subfolder

### DIFF
--- a/notebooks/3_Building_your_own_net_With_Answers.ipynb
+++ b/notebooks/3_Building_your_own_net_With_Answers.ipynb
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/mataney/PyTorchCourse/blob/master/3_Building_your_own_net_With_Answers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/mataney/PyTorchCourse/blob/master/notebooks/3_Building_your_own_net_With_Answers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
@mataney typo fix to open in colab